### PR TITLE
fix deprecation warning [LSP] Accessing client.resolved_capabilities …

### DIFF
--- a/config/nvim/lua/user/lsp/handlers.lua
+++ b/config/nvim/lua/user/lsp/handlers.lua
@@ -76,7 +76,7 @@ end
 M.on_attach = function(client, bufnr)
 	if client.name == "tsserver" then
 		-- Turn off document formatting so we can use prettier
-		client.resolved_capabilities.document_formatting = false
+		client.server_capabilities.document_formatting = false
 	end
 	lsp_keymaps(bufnr)
 	lsp_highlight_document(client)


### PR DESCRIPTION
…is deprecated, update your plugins or configuration to access client.server_capabilities instead.The new key/value pairs in server_capabilities d irectly match those defined in the language server protocol