### PR TITLE
feat: cd history ignores /tmp

### DIFF
--- a/shell/dir_jumping.sh
+++ b/shell/dir_jumping.sh
@@ -11,6 +11,8 @@ function changeDirShortcut {
 function __pushchangeddirToListSave {
 	# return from function if the current working directory contains _worktrees_git
 	if [[ $(pwd) == *"_worktrees_git"* ]] && return;
+	# return from funtion if the current working directory contains /tmp
+	if [[ $(pwd) == *"/tmp"* ]] && return;
   cdhistory="$HOME/.cache/cdhistory"
   touch "$cdhistory"
 	echo "$(pwd | sed 's/ /<spc;>/') $(date +'%s')" >> "$cdhistory"


### PR DESCRIPTION
Now we have `cdp` to naviate a project internally we can stop tracking `/tmp` jumps so we don't have the history filled with temporary filepaths