### PR TITLE
feat(shell): project jump improvements

### DIFF
--- a/shell/.zshrc
+++ b/shell/.zshrc
@@ -151,6 +151,7 @@ alias rgf="rg -uu --files | rg --invert-match \.git | rg"
 
 source ~/.dotfiles/shell/git_extras.sh
 source ~/.dotfiles/shell/dir_jumping.sh
+source ~/.dotfiles/shell/lib/lib.sh
 
 #git diff list
 alias gdl="getDiffByList"

--- a/shell/dir_jumping.sh
+++ b/shell/dir_jumping.sh
@@ -39,7 +39,7 @@ function changeDirFromHistory {
 # Works in a git repo or in a worktree
 function changeDirInsideGitProject {
 	top_level="$(git rev-parse --show-toplevel)"
-	chosen_dir=$(cd "$top_level" && fd --type directory | fzf --header "Project Jump")
+	chosen_dir=$(cd "$top_level" && echo "$(fd --type directory)\n/" | fzf --tac --no-sort --header "Project Jump")
 	chosen_dir="$top_level/$chosen_dir"
   if [[ -d "$chosen_dir" ]]; then
 		pushChangedDirToList "$chosen_dir"

--- a/shell/dir_jumping.sh
+++ b/shell/dir_jumping.sh
@@ -29,7 +29,7 @@ function pushChangedDirToList {
 # Use fzf to choose a dir to jump to from the history
 function changeDirFromHistory {
   cdhistory="$HOME/.cache/cdhistory"
-	chosen_dir=$(rev "$cdhistory" | cut -d" " -f 2-  | rev | sed 's/<spc;>/ /' | fzf --tac --header "History Jump")
+	chosen_dir=$(eval "$(fzfLsPreview "History Jump")" <<< "$(rev "$cdhistory" | cut -d" " -f 2-  | rev | sed 's/<spc;>/ /')" )
   if [[ -d "$chosen_dir" ]]; then
 		pushChangedDirToList "$chosen_dir"
   fi
@@ -39,8 +39,7 @@ function changeDirFromHistory {
 # Works in a git repo or in a worktree
 function changeDirInsideGitProject {
 	top_level="$(git rev-parse --show-toplevel)"
-	chosen_dir=$(cd "$top_level" && echo "$(fd --type directory)\n/" \
-		| fzf --ansi --tac --header "Project Jump" --preview 'CLICOLOR_FORCE=1 ls -al -G --color=auto {}')
+	chosen_dir=$(eval "$(fzfLsPreview "Project Jump")" <<< "$(cd "$top_level" && echo "$(fd --type directory)\n/")" )
 	chosen_dir="$top_level/$chosen_dir"
   if [[ -d "$chosen_dir" ]]; then
 		pushChangedDirToList "$chosen_dir"

--- a/shell/dir_jumping.sh
+++ b/shell/dir_jumping.sh
@@ -39,7 +39,8 @@ function changeDirFromHistory {
 # Works in a git repo or in a worktree
 function changeDirInsideGitProject {
 	top_level="$(git rev-parse --show-toplevel)"
-	chosen_dir=$(cd "$top_level" && echo "$(fd --type directory)\n/" | fzf --tac --no-sort --header "Project Jump")
+	chosen_dir=$(cd "$top_level" && echo "$(fd --type directory)\n/" \
+		| fzf --ansi --tac --header "Project Jump" --preview 'CLICOLOR_FORCE=1 ls -al -G --color=auto {}')
 	chosen_dir="$top_level/$chosen_dir"
   if [[ -d "$chosen_dir" ]]; then
 		pushChangedDirToList "$chosen_dir"

--- a/shell/lib/lib.sh
+++ b/shell/lib/lib.sh
@@ -13,4 +13,6 @@ confirm() {
     esac
 }
 
-echo "Sourced this file"
+fzfLsPreview() {
+	echo "fzf --ansi --tac --header \"$1\" --preview 'CLICOLOR_FORCE=1 ls -al -G --color=auto {}'"
+}

--- a/shell/lib/lib.sh
+++ b/shell/lib/lib.sh
@@ -13,6 +13,11 @@ confirm() {
     esac
 }
 
+# Use FZF to preview a list of directories using `eval` where you pipe in using <<< the directories stream
+# See usage in `changeDirInsideGitProject` as an example.
+# `CLICOLOR_FORCE=1` is needed to force color output in `ls`, along with `-G` for mac and `--color=auto` for linux
+# `--ansi` is needed to force color output in fzf reading the ANSI colour codes
+# `"$1"` sets the title shown in the fzf box.
 fzfLsPreview() {
 	echo "fzf --ansi --tac --header \"$1\" --preview 'CLICOLOR_FORCE=1 ls -al -G --color=auto {}'"
 }


### PR DESCRIPTION
* Project jump now has `/` too so you can easily jump to the project root
* Add fzf preview for both directory jumping commands
* FZF preview uses a special function to force colourisation

In future it would be ideal to try and make the previewer when looking at git changes for a directory to use this too