### PR TITLE
feat(nvim): disable code folding in telescope preview window

### DIFF
--- a/config/nvim/lua/user/telescope.lua
+++ b/config/nvim/lua/user/telescope.lua
@@ -3,10 +3,13 @@ if not status_ok then
 	return
 end
 
-telescope.setup {
+telescope.setup({
 	defaults = {
 		file_ignore_patterns = {
-			"node_modules"
-		}
-	}
-}
+			"node_modules",
+		},
+	},
+})
+
+-- Disable folding in Telescope's result window.
+vim.api.nvim_create_autocmd("FileType", { pattern = "TelescopeResults", command = [[setlocal foldlevelstart=999]] })


### PR DESCRIPTION
Adapted from https://github.com/nvim-telescope/telescope.nvim/issues/991