### PR TITLE
fix(nvim): temporary workaround for tsserver deprecated config

### DIFF
--- a/config/nvim/lua/user/lsp/mason.lua
+++ b/config/nvim/lua/user/lsp/mason.lua
@@ -38,6 +38,7 @@ local opts = {}
 
 for _, server in pairs(servers) do
 	-- print(server)
+	server = server == 'tsserver' and 'ts_ls' or server
 	opts = {
 		on_attach = require("user.lsp.handlers").on_attach,
 		capabilities = require("user.lsp.handlers").capabilities,


### PR DESCRIPTION
1. Recently nvim changed `tsserver` to `ts_ls` and deprecated the former https://github.com/neovim/nvim-lspconfig/pull/3232
2. Mason (the tool to install the language servers) hasn't been uupdated yet, so for now the workaround is to just catch the initialisation of the `tsserver` and rename it to `ts_ls`. 
3. In future once mason has fixed the issue we can update properly

https://github.com/neovim/nvim-lspconfig/pull/3232
https://github.com/williamboman/mason-lspconfig.nvim/issues/458