### PR TITLE
feat(shell): stream llm response to file and stdout

### DIFF
--- a/shell/ai.sh
+++ b/shell/ai.sh
@@ -82,7 +82,7 @@ function openLLMinEditor {
 						cat "$tempfile" | llm
         fi
     else
-        echo "No input detected"
+        echo "No input detected. Skipping LLM processing."
     fi
 
     # If not persistent, remove the tempfile

--- a/shell/ai.sh
+++ b/shell/ai.sh
@@ -71,21 +71,15 @@ function openLLMinEditor {
             # Compare the md5sum after editing with the initial md5sum
             current_md5sum=$(md5sum "$tempfile" | awk '{print $1}')
             if [ "$initial_md5sum" != "$current_md5sum" ]; then
-                local llm_response
-                llm_response=$(cat "$tempfile" | llm)
-                echo "$llm_response"
-
                 echo -e "
 =======response========
 " >> "$tempfile"
-                echo "$llm_response" >> "$tempfile"
+                cat "$tempfile" | llm "Don't ever create additional user inputs" | tee -a "$tempfile"
             else
                 echo "No input detected. Skipping LLM processing."
             fi
         else
-            local llm_response
-            llm_response=$(cat "$tempfile" | llm)
-            echo "$llm_response"
+						cat "$tempfile" | llm
         fi
     else
         echo "No input detected"


### PR DESCRIPTION
Previously because we saved the llm response in a local variable you'd not see any output until the entire response is generated. This change now allows each chunk to be shown on STDOUT as soon as it's received from the llm