### PR TITLE
feat: display llm output with bat to get syntax highlighting

### DIFF
--- a/shell/ai.sh
+++ b/shell/ai.sh
@@ -1,5 +1,6 @@
 handle_llm_output() {
     local input=$1
+		local tempfile=$2  # Add tempfile as second parameter
 
     # Save screen and switch to alternate screen
     echo -en "\033[?1049h"
@@ -138,13 +139,13 @@ function openLLMinEditor {
             if [ "$initial_md5sum" != "$current_md5sum" ]; then
                 echo -e "\n=======response========" >> "$tempfile"
                 # New streaming output with bat formatting
-								handle_llm_output "$(cat "$tempfile")" true
+								handle_llm_output "$(cat "$tempfile")" "$tempfile"
             else
                 echo "No input detected. Skipping LLM processing."
             fi
         else
             # For non-persistent mode, just use bat directly
-						handle_llm_output "$(cat "$tempfile")" true
+						handle_llm_output "$(cat "$tempfile")"
         fi
     else
         echo "No input detected. Skipping LLM processing."

--- a/shell/ai.sh
+++ b/shell/ai.sh
@@ -1,8 +1,8 @@
-handle_llm_output() {
+call_llm_and_handle() {
     local input=$1
-		local tempfile=$2  # Add tempfile as second parameter
+    local tempfile=$2  # Add tempfile as second parameter
 
-		    local prompt
+    local prompt
     read -r -d '' prompt << 'EOF'
 You are a helpful assistant. Please follow these guidelines:
 - Use markdown formatting when appropriate - when adding code blocks please always tag the language name after the backticks
@@ -10,13 +10,13 @@ You are a helpful assistant. Please follow these guidelines:
 EOF
 
     # Save screen and switch to alternate screen
-    echo -en "\033[?1049h"
+    echo -en "[?1049h"
 
     # Stream output and capture it
     temp_output=$(echo "$input" | llm "$prompt" | tee /dev/tty)
 
     # Switch back to main screen
-    echo -en "\033[?1049l"
+    echo -en "[?1049l"
 
     # Display formatted output
     echo "$temp_output" | bat --paging=never --theme="OneHalfDark" --color always -p -l md
@@ -138,21 +138,19 @@ function openLLMinEditor {
         $editor "$tempfile"
     fi
 
-		# Check if tempfile exists and is non-empty
+    # Check if tempfile exists and is non-empty
     if [ -s "$tempfile" ]; then
         if $thread || $persist; then
             # Compare the md5sum after editing with the initial md5sum
             current_md5sum=$(md5sum "$tempfile" | awk '{print $1}')
             if [ "$initial_md5sum" != "$current_md5sum" ]; then
                 echo -e "\n=======response========" >> "$tempfile"
-                # New streaming output with bat formatting
-								handle_llm_output "$(cat "$tempfile")" "$tempfile"
+                call_llm_and_handle "$(cat "$tempfile")" "$tempfile"
             else
                 echo "No input detected. Skipping LLM processing."
             fi
         else
-            # For non-persistent mode, just use bat directly
-						handle_llm_output "$(cat "$tempfile")"
+            call_llm_and_handle "$(cat "$tempfile")"
         fi
     else
         echo "No input detected. Skipping LLM processing."

--- a/shell/ai.sh
+++ b/shell/ai.sh
@@ -2,17 +2,24 @@ handle_llm_output() {
     local input=$1
 		local tempfile=$2  # Add tempfile as second parameter
 
+		    local prompt
+    read -r -d '' prompt << 'EOF'
+You are a helpful assistant. Please follow these guidelines:
+- Use markdown formatting when appropriate - when adding code blocks please always tag the language name after the backticks
+- Stay focused on the user's question - Don't create additional user prompts
+EOF
+
     # Save screen and switch to alternate screen
     echo -en "\033[?1049h"
 
     # Stream output and capture it
-    temp_output=$(echo "$input" | llm "Don't ever create additional user inputs" | tee /dev/tty)
+    temp_output=$(echo "$input" | llm "$prompt" | tee /dev/tty)
 
     # Switch back to main screen
     echo -en "\033[?1049l"
 
     # Display formatted output
-    echo "$temp_output" | bat --paging=never
+    echo "$temp_output" | bat --paging=never --theme="OneHalfDark" --color always -p -l md
 
     # If we need to append to tempfile (for thread/persist mode)
     if [ -n "$tempfile" ]; then


### PR DESCRIPTION
Because bat doesn't work with paging for syntax higlhighting and also the llm takes a while to respond we output in two phases
1. Output as normal but to the alternative screen. This is so we can observe the stream coming in and don't have to wait for ages
2. Output the response into bat on the normal terminal to receive syntax highlighting

We use the alternative screen to ensure that we don't see the output there twice. At first I did try ways to output both on the main screen and clear up the first before trying the second, but this was flaky