### PR TITLE
fix(shell): regression for opening the alternative shell screen

### DIFF
--- a/shell/ai.sh
+++ b/shell/ai.sh
@@ -10,13 +10,13 @@ You are a helpful assistant. Please follow these guidelines:
 EOF
 
     # Save screen and switch to alternate screen
-    echo -en "[?1049h"
+    echo -en "\033[?1049h"
 
     # Stream output and capture it
     temp_output=$(echo "$input" | llm "$prompt" | tee /dev/tty)
 
     # Switch back to main screen
-    echo -en "[?1049l"
+    echo -en "\033[?1049l"
 
     # Display formatted output
     echo "$temp_output" | bat --paging=never --theme="OneHalfDark" --color always -p -l md


### PR DESCRIPTION
Fixes regression in https://github.com/matteematt/.dotfiles/pull/174/commits/4156f6e4abb92549c25a20d8bb3fd4efe5cb2ee3 which broke the command to open the alternative screen