### PR TITLE
Shell/misc improvements 2

### DIFF
--- a/config/tmux/scripts/cheatsheet.sh
+++ b/config/tmux/scripts/cheatsheet.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Searchable cheatsheet of tmux prefix-table bindings. Annotated (custom)
+# bindings are emitted last — with fzf's default layout the end of input
+# is rendered immediately above the prompt, so they're what the eye lands
+# on first.
+
+noted=$(tmux list-keys -N -T prefix)
+# `-aN` shows every key, substituting the note where one exists. Subtract
+# the noted lines to get only the defaults.
+defaults=$(tmux list-keys -aN -T prefix | grep -vFxf <(printf '%s\n' "$noted"))
+
+{ printf '%s\n' "$defaults"; printf '%s\n' "$noted"; } \
+    | fzf --prompt='bindings> '

--- a/config/tmux/scripts/kill_sessions.sh
+++ b/config/tmux/scripts/kill_sessions.sh
@@ -12,11 +12,12 @@ if [ -z "$sessions" ]; then
 fi
 
 # Use fzf to select sessions (multiple selection with -m flag)
-selected_sessions=$(echo "$sessions" | fzf -m \
+selected_sessions=$(echo "$sessions" | fzf -m --ansi \
     --prompt="Select sessions to kill: " \
     --preview="$(dirname "$0")/session_preview.sh {}" \
-    --preview-window=up:90% \
-    --header="Tab: select/deselect | Ctrl+A: select all | Ctrl+D: deselect all | Enter: confirm")
+    --preview-window=up:85% \
+    --bind 'ctrl-u:preview-up,ctrl-d:preview-down,ctrl-b:preview-page-up,ctrl-f:preview-page-down' \
+    --header="Tab: select/deselect | Ctrl-u/d: scroll preview | Ctrl-b/f: page preview | Enter: confirm")
 
 if [ -z "$selected_sessions" ]; then
     echo "No sessions selected"

--- a/config/tmux/scripts/name_session_from_git.sh
+++ b/config/tmux/scripts/name_session_from_git.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Rename the current tmux session to "<repo>/<branch>" based on the focused
+# pane's working directory. Falls back to a short SHA when HEAD is detached.
+
+set -eu
+
+cwd=$(tmux display -p '#{pane_current_path}')
+
+if ! git_common=$(git -C "$cwd" rev-parse --git-common-dir 2>/dev/null); then
+    tmux display-message "Not in a git repo"
+    exit 0
+fi
+
+# `--git-common-dir` points at the shared `.git`, so its parent is the main
+# repo root even when we're sitting inside a worktree (where `--show-toplevel`
+# would give the worktree dir instead).
+git_common_abs=$(cd "$cwd" && cd "$git_common" && pwd)
+repo=$(basename "$(dirname "$git_common_abs")")
+branch=$(git -C "$cwd" rev-parse --abbrev-ref HEAD)
+
+# Detached HEAD → use a short SHA so the name still distinguishes the session.
+if [[ "$branch" == "HEAD" ]]; then
+    branch=$(git -C "$cwd" rev-parse --short HEAD)
+fi
+
+name="${repo}(${branch})"
+
+# tmux session names cannot contain `.` or `:`.
+name=${name//./-}
+name=${name//:/-}
+
+# A leading dash would be mistaken for a flag by tmux; strip any.
+while [[ "$name" == -* ]]; do name=${name#-}; done
+[[ -z "$name" ]] && { tmux display-message "Derived session name is empty"; exit 0; }
+
+current=$(tmux display -p '#S')
+
+if [[ "$name" == "$current" ]]; then
+    tmux display-message "Session already named '$name'"
+    exit 0
+fi
+
+# Suffix on collision (e.g. two worktrees on the same branch).
+candidate=$name
+n=2
+while tmux has-session -t="=$candidate" 2>/dev/null; do
+    candidate="${name}-${n}"
+    n=$((n + 1))
+done
+
+tmux rename-session -t "$current" "$candidate"
+tmux display-message "Session renamed to '$candidate'"

--- a/config/tmux/scripts/session_name_if_fits.sh
+++ b/config/tmux/scripts/session_name_if_fits.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Print the current session name (with trailing space) only when it fits
+# alongside the window tabs and right-side status within the client's width.
+#
+# Usage: session_name_if_fits.sh [LEFT_PADDING]
+#   LEFT_PADDING: columns reserved to the left of this output (default 0).
+#                 Set to match any leading spaces in `status-left`.
+#
+# Width budget:
+#   left_padding + windows_total + session_label + status_right <= client_width
+
+set -eu
+
+# Width reserved for leading spaces in status-left. Override per-platform.
+left_padding=${1:-0}
+
+session_name=$(tmux display -p '#S')
+
+# Skip tmux's auto-generated numeric names — only surface names the user set.
+if [[ "$session_name" =~ ^[0-9]+$ ]]; then
+    exit 0
+fi
+
+client_width=$(tmux display -p '#{client_width}')
+
+# Approximate rendered width of `status-right` ("HH:MM:SS | Weekday DD Mon  ").
+status_right=30
+
+# Per-tab overhead: leading space + "N: " + trailing space, plus one separator.
+# Widest index assumed single-digit; bump to 7 if you routinely go past 9 tabs.
+tab_overhead=6
+
+windows_total=0
+while IFS= read -r name; do
+    windows_total=$((windows_total + ${#name} + tab_overhead))
+done < <(tmux list-windows -F '#W')
+
+# " name " — trailing space so it doesn't butt against the first tab.
+session_label=$((${#session_name} + 1))
+
+required=$((left_padding + windows_total + session_label + status_right))
+
+if (( required <= client_width )); then
+    printf '%s ' "$session_name"
+fi

--- a/config/tmux/scripts/session_preview.sh
+++ b/config/tmux/scripts/session_preview.sh
@@ -75,7 +75,8 @@ else
             printf '%*s\n' "${COLUMNS:-80}" '' | tr ' ' '-'
             
             # Capture and display pane content (last 18 lines)
-            content=$(tmux capture-pane -t "$session:$pane" -p 2>/dev/null | tail -18)
+            # `-e` preserves ANSI colour/style escapes so fzf (with --ansi) can render them
+            content=$(tmux capture-pane -e -t "$session:$pane" -p 2>/dev/null | tail -18)
             if [ -n "$content" ]; then
                 echo "$content"
             else

--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -53,6 +53,9 @@ bind "a" run-shell -b "~/.config/tmux/plugins/tmux-fzf/scripts/window.sh switch"
 # Interactive session killer with multi-select capability
 bind k new-window "~/.dotfiles/config/tmux/scripts/kill_sessions.sh"
 
+# Rename current session (pre-fills with current name)
+bind R command-prompt -I "#S" "rename-session '%%'"
+
 ######################
 ### DESIGN CHANGES ###
 ######################
@@ -71,7 +74,7 @@ set -g pane-border-style bg="default",fg="#686868"
 set -g pane-active-border-style "#{?pane_in_mode,bg=default fg=magenta,bg=default fg=cyan}"
 
 # The statusbar
-set -g status-interval 2                # frequency in seconds of refresh
+set -g status-interval 1                # frequency in seconds of refresh
 set -g status-position top              # where to show the status bar in the terminal
 set -g status-justify left              # where to show the window status in the bar
 set -g status-style bg="default",fg="blue"
@@ -102,7 +105,6 @@ set -g window-status-bell-style fg=colour255,bg=colour1,bold
 set -g message-command-style fg=blue,bg=default
 set -g message-style fg="cyan",bg="default",bold
 
-set-option -g status-interval 5
 set-option -g automatic-rename on
 set-option -g automatic-rename-format "#{b:pane_current_path} [#{pane_current_command}]"
 

--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -60,7 +60,7 @@ bind -N "Rename current session (editable)" R command-prompt -I "#S" "rename-ses
 bind -N "Name session from git repo + branch" N run-shell "~/.dotfiles/config/tmux/scripts/name_session_from_git.sh"
 
 # Searchable popup cheatsheet of all prefix-table bindings
-bind -N "Cheatsheet of bindings (fzf popup)" ? display-popup -E -w 80% -h 80% "~/.dotfiles/config/tmux/scripts/cheatsheet.sh"
+bind -N "Cheatsheet of bindings (fzf popup)" ? display-popup -E -w 90% -h 90% "~/.dotfiles/config/tmux/scripts/cheatsheet.sh"
 
 ######################
 ### DESIGN CHANGES ###

--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -56,6 +56,9 @@ bind k new-window "~/.dotfiles/config/tmux/scripts/kill_sessions.sh"
 # Rename current session (pre-fills with current name)
 bind R command-prompt -I "#S" "rename-session '%%'"
 
+# Name current session from its git repo + branch (based on focused pane's cwd)
+bind N run-shell "~/.dotfiles/config/tmux/scripts/name_session_from_git.sh"
+
 ######################
 ### DESIGN CHANGES ###
 ######################

--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -4,7 +4,7 @@
 set -sg escape-time 10
 
 # reload config file (change file location to your the tmux.conf you want to use)
-bind r source ~/.config/tmux/tmux.conf\; display-message "Config reloaded..."
+bind -N "Reload tmux config" r source ~/.config/tmux/tmux.conf\; display-message "Config reloaded..."
 
 # Enable mouse mode (tmux 2.1 and above)
 set -g mouse on
@@ -25,39 +25,42 @@ unbind C-b
 set-option -g prefix C-a
 bind-key C-a send-prefix
 
-bind t new-window -c '#{pane_current_path}'
-bind w confirm-before -p "kill-window #W? (y/n)" kill-window
+bind -N "New window in current pane's cwd" t new-window -c '#{pane_current_path}'
+bind -N "Kill current window (with confirm)" w confirm-before -p "kill-window #W? (y/n)" kill-window
 
-bind c choose-tree
+bind -N "Choose session/window tree" c choose-tree
 
-bind p confirm-before -p "kill-pane #P? (y/n)" kill-pane
+bind -N "Kill current pane (with confirm)" p confirm-before -p "kill-pane #P? (y/n)" kill-pane
 
 unbind '"'
 unbind %
-bind -   split-window -c "#{pane_current_path}"
-bind |   split-window -h -c "#{pane_current_path}"
+bind -N "Split pane horizontally (same cwd)" -   split-window -c "#{pane_current_path}"
+bind -N "Split pane vertically (same cwd)"   |   split-window -h -c "#{pane_current_path}"
 
-bind h select-pane -L
-bind j select-pane -D
-bind k select-pane -U
-bind l select-pane -R
+bind -N "Select pane to the left"  h select-pane -L
+bind -N "Select pane below"        j select-pane -D
+bind -N "Select pane above"        k select-pane -U
+bind -N "Select pane to the right" l select-pane -R
 
-bind -n M-j previous-window
-bind -n M-k next-window
+bind -n -N "Previous window (no prefix)" M-j previous-window
+bind -n -N "Next window (no prefix)"     M-k next-window
 
-bind-key S command-prompt -p 'save history to filename:' -I '~/tmux.history' 'capture-pane -S -; save-buffer %1 ; delete-buffer'
+bind-key -N "Save pane history to a file" S command-prompt -p 'save history to filename:' -I '~/tmux.history' 'capture-pane -S -; save-buffer %1 ; delete-buffer'
 
 # 'list' windows
-bind "a" run-shell -b "~/.config/tmux/plugins/tmux-fzf/scripts/window.sh switch"
+bind -N "Fzf window switcher" "a" run-shell -b "~/.config/tmux/plugins/tmux-fzf/scripts/window.sh switch"
 
-# Interactive session killer with multi-select capability
-bind k new-window "~/.dotfiles/config/tmux/scripts/kill_sessions.sh"
+# Interactive session killer with multi-select capability (floating popup)
+bind -N "Kill sessions (popup, multi-select)" k display-popup -E -w 90% -h 90% "~/.dotfiles/config/tmux/scripts/kill_sessions.sh"
 
 # Rename current session (pre-fills with current name)
-bind R command-prompt -I "#S" "rename-session '%%'"
+bind -N "Rename current session (editable)" R command-prompt -I "#S" "rename-session '%%'"
 
 # Name current session from its git repo + branch (based on focused pane's cwd)
-bind N run-shell "~/.dotfiles/config/tmux/scripts/name_session_from_git.sh"
+bind -N "Name session from git repo + branch" N run-shell "~/.dotfiles/config/tmux/scripts/name_session_from_git.sh"
+
+# Searchable popup cheatsheet of all prefix-table bindings
+bind -N "Cheatsheet of bindings (fzf popup)" ? display-popup -E -w 80% -h 80% "~/.dotfiles/config/tmux/scripts/cheatsheet.sh"
 
 ######################
 ### DESIGN CHANGES ###

--- a/config/tmux/tmux.macos.conf
+++ b/config/tmux/tmux.macos.conf
@@ -1,5 +1,7 @@
-# Padding is added here to get the tmux status bar out of the way of the MacOS window controls in the top left corner
-set -g status-left "       "
+# Padding to keep the status bar clear of MacOS window controls.
+# Append session name after the padding when the client is wide enough to fit
+# it alongside the window tabs and right-side status (see the helper script).
+set -g status-left '       #[fg=cyan,bold]#(~/.dotfiles/config/tmux/scripts/session_name_if_fits.sh 7)#[default]'
 bind-key : command-prompt -p '      '
 
 # Set vim mode for copy mode and allow us to use v and y actions

--- a/shell/git_extras.sh
+++ b/shell/git_extras.sh
@@ -76,7 +76,7 @@ function gitViewAndStage() {
     return 0
   fi
 
-  chosen_files=$(__formatGitStatus | fzf -m --with-nth 2 --header "File Staging (TAB to select multiple)" --preview-window=right,70% --preview '$HOME/.dotfiles/shell/view_git_unstaged_file.sh {}')
+  chosen_files=$(__formatGitStatus | fzf -m --with-nth 2 --header "File Staging (TAB to select multiple, ctrl-u/ctrl-d to scroll preview)" --preview-window=right,70% --bind 'ctrl-u:preview-up,ctrl-d:preview-down,ctrl-b:preview-page-up,ctrl-f:preview-page-down' --preview '$HOME/.dotfiles/shell/view_git_unstaged_file.sh {}')
   if [ -z "$chosen_files" ]; then
     return
   else


### PR DESCRIPTION
  Tmux — session naming & visibility

  - C-a R binding to rename the current session with the current name pre-filled for editing
  - C-a N binding to auto-name the session as repo(branch) based on the focused pane's git context; handles worktrees (uses --git-common-dir, so it resolves to the main repo rather than the worktree dir), detached HEAD (falls back to short SHA), forbidden chars (./: → -),
  leading-dash sanitization, and collision-suffixes (-2, -3, …)
  - Session name in the macOS status-left when the terminal is wide enough — new session_name_if_fits.sh sums left-padding + window-tab widths + status-right estimate and only emits the name when it fits; skips tmux's default numeric names; left_padding is now a CLI arg so the
  script is reusable
  - status-interval consolidated to 1s (was 2s and a later 5s override) so the script reflects changes more promptly

  Tmux — popups

  - C-a k (kill sessions) moved from a new window to a floating popup (display-popup, 90×90)
  - Colour-rich pane previews in the kill picker — session_preview.sh now captures with -e and fzf renders via --ansi, so prompts/vim/syntax all show through as they do live
  - C-a ? cheatsheet popup — cheatsheet.sh shows all prefix-table bindings via fzf, with custom (annotated) bindings listed last so they render nearest the prompt cursor in fzf's default layout
  - -N "description" annotations on every custom prefix binding so the cheatsheet reads as human-friendly descriptions rather than raw tmux commands

  Fzf (separate commit)

  - gitViewAndStage in shell/git_extras.sh — added preview-scroll bindings (ctrl-u/d/b/f) and updated the header to document them
