### PR TITLE
feat: ai improvements for handoff doc and tmux quiet bell

### DIFF
--- a/ai/skills/handoff/SKILL.md
+++ b/ai/skills/handoff/SKILL.md
@@ -1,10 +1,17 @@
 ---
 name: handoff
 description: Compact the current conversation into a handoff document for another agent to pick up.
-argument-hint: "What will the next session be used for?"
+argument-hint: "What will the next session be used for? (add --tmp to write to /tmp instead of the repo root)"
 ---
 
-Write a handoff document summarising the current conversation so a fresh agent can continue the work. Save to the temporary directory of the user's OS - not the current workspace.
+Write a handoff document summarising the current conversation so a fresh agent can continue the work.
+
+**Where to save it:**
+- By default, save it to the root of the current repository — the path returned by `git rev-parse --show-toplevel`.
+- If the user passes the `--tmp` flag, save it to `/tmp` instead. Always use `/tmp` literally; do not substitute `$TMPDIR` or any other OS-specific temporary directory, since those vary between machines and agents pick inconsistent locations.
+- If the default (repo root) is selected but the working directory is not inside a git repository, fall back to `/tmp` — and tell the user explicitly that you did so because you're not in a git repo, rather than silently writing to `/tmp`.
+
+Always report the final path where you saved the document.
 
 Give the file a verbose, descriptive name derived from the handoff contents (e.g. the repo/project, task, and a short topic slug) so it is easy to identify later among other handoffs. Use kebab-case with a date prefix, e.g. `2026-05-27-dotfiles-ai-skills-install-script-handoff.md`.
 

--- a/config/tmux/scripts/claude_notify.sh
+++ b/config/tmux/scripts/claude_notify.sh
@@ -38,6 +38,13 @@ front=$(lsappinfo info -only name "$(lsappinfo front 2>/dev/null)" 2>/dev/null)
 case "$front" in *"$TERM_APP"*) exit 0 ;; esac
 
 # You've left the terminal for another app → pop a notification to pull you back.
+# Message reflects which event fired: Stop = response complete and idle;
+# permission_prompt = blocked mid-task waiting for your approval.
+if [ "$event" = "Stop" ]; then
+  msg="finished"
+else
+  msg="needs approval"
+fi
 if command -v osascript >/dev/null 2>&1; then
-  osascript -e "display notification \"needs you\" with title \"Claude · ${sess}\" sound name \"Submarine\"" >/dev/null 2>&1
+  osascript -e "display notification \"${msg}\" with title \"Claude · ${sess}\" sound name \"Submarine\"" >/dev/null 2>&1
 fi

--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -39,9 +39,12 @@ bind -N "Choose session tree (with [!] alert markers)" s choose-tree -Zs -F '#{?
 
 bind -N "Toggle between last two sessions" Space switch-client -l
 
-# Toggle "flag this window when it goes quiet" — for long non-Claude commands
-# (builds/tests). When output stops for 15s the window alerts (shows in SESSION_ALERTS_).
-bind -N "Toggle 'flag when quiet' (monitor-silence) on this window" m if -F '#{monitor-silence}' 'setw monitor-silence 0 ; display "quiet-alert: off"' 'setw monitor-silence 15 ; display "quiet-alert: on (15s)"'
+# "Flag this window when it goes quiet" — for long non-Claude commands (builds/tests).
+# prefix+m toggles per-window: if it's currently on, this turns it off; if it's off,
+# it opens a prompt for the silence timeout in seconds (pre-filled with 15 — press
+# Enter to accept, or type a larger number for longer-running work). When output then
+# stops for that many seconds the window alerts (shows in SESSION_ALERTS_).
+bind -N "Flag-when-quiet: on→toggle off, off→prompt for secs (monitor-silence)" m if -F '#{monitor-silence}' 'setw monitor-silence 0 ; display "quiet-alert: off"' 'command-prompt -p "flag-when-quiet seconds:" -I "15" "setw monitor-silence %1 ; display \"quiet-alert: on (%1s)\""'
 
 bind -N "Kill current pane (with confirm)" p confirm-before -p "kill-pane #P? (y/n)" kill-pane
 


### PR DESCRIPTION
1. IMprove claude notification messgae when Alacritty is in background
2. /handoff skill writes into repo base by default instead of tmp
3. allows configuration of tmux quiet alert length