### PR TITLE
feat(ai): claude busy notificaiton and full terminal config

### DIFF
--- a/ai/claude/settings.json
+++ b/ai/claude/settings.json
@@ -50,5 +50,6 @@
   "effortLevel": "xhigh",
   "theme": "dark",
   "editorMode": "vim",
-  "skipAutoPermissionPrompt": true
+  "skipAutoPermissionPrompt": true,
+  "tui": "fullscreen"
 }

--- a/config/tmux/scripts/claude_notify.sh
+++ b/config/tmux/scripts/claude_notify.sh
@@ -1,32 +1,67 @@
 #!/usr/bin/env bash
-# Claude Code Stop + Notification hook — pings so you know to go back to a window.
-# Acts on: Stop (Claude finished a response) and Notification/permission_prompt
-# (Claude is blocked needing approval). Ignores Notification/idle_prompt (a ~60s
-# "still waiting" nag that fires even after you've seen the result and moved on)
-# and the MCP auth/elicitation notification types.
-# To avoid pinging a window you're actively working in, it stays SILENT whenever
-# your tmux client is already sitting on the Claude window (you'll see it when you
-# look at the terminal). It only flags/pops for a window you've moved away from:
-# rings the bell on the pane (so tmux flags the window in the SESSION_ALERTS_ strip
-# and the prefix+s [!] marker) and pops a macOS notification to pull you back.
+# Claude Code Stop + Notification hook — signals across tmux so you know a window
+# needs you, WITHOUT falsely crying "done" when the agent has only paused.
+#
+# Three outcomes:
+#   1. DONE     (Stop, no background work) — agent finished and control is back
+#               with you. Rings the tmux bell (window flags red in the
+#               SESSION_ALERTS_ strip + the prefix+s [!] marker) and pops a macOS
+#               notification with sound. Clears the pending marker.
+#   2. PENDING  (Stop, but background_tasks still running) — the agent went idle
+#               yet will AUTO-RESUME when a background shell/subagent finishes.
+#               No bell, no sound, NO macOS notification: just a passive ⋯ marker
+#               on the window tab (the @claude_pending user option, rendered in
+#               tmux.conf). It's set regardless of which app/window is focused, so
+#               it's there whenever you glance over — that tab marker is the whole
+#               signal for this case, since nothing actually needs you.
+#   3. APPROVAL (Notification/permission_prompt) — blocked mid-task needing your
+#               approval. Bell + macOS notification with sound.
+#
+# background_tasks is a JSON array on the Stop payload (Claude Code 2.1.145+);
+# each entry is a running shell ("type":"shell") OR subagent ("type":"subagent").
+# Empty array ⇒ truly done. It is null on Notification events, so we only trust it
+# for Stop. Verified empirically (both task kinds appear) before relying on it.
+#
+# For DONE/APPROVAL the bell/notification stay SILENT whenever your tmux client is
+# already sitting on the Claude window — you'll see it when you look.
 
 payload=$(cat)   # the hook JSON on stdin
 event=$(printf '%s' "$payload" | jq -r '.hook_event_name // empty'   2>/dev/null)
 ntype=$(printf '%s' "$payload" | jq -r '.notification_type // empty' 2>/dev/null)
+# Running background tasks (shells + subagents). null/empty/absent all collapse to 0.
+pending=$(printf '%s' "$payload" | jq '(.background_tasks | length) // 0' 2>/dev/null)
+[ -z "$pending" ] && pending=0
 
 [ -z "${TMUX:-}" ] && exit 0   # not inside tmux → nothing to flag
+
+p="${TMUX_PANE:-}"
 
 # Only a permission_prompt notification is worth a ping; ignore idle_prompt (Stop
 # already covers "done while away") and the MCP auth/elicitation types.
 [ "$event" = "Notification" ] && [ "$ntype" != "permission_prompt" ] && exit 0
 
-p="${TMUX_PANE:-}"
+# Reconcile the passive pending marker on every Stop, regardless of focus, so it
+# reflects reality whether or not you're looking.
+#   PENDING → set ⋯ and stop here: the tab marker is the entire signal (no bell,
+#             no notification). It clears when you switch to the window
+#             (session-window-changed hook in tmux.conf) or on the next DONE Stop,
+#             so it can't get stuck after an interrupted/crashed session.
+#   DONE    → clear ⋯ and fall through to the bell + "finished" notification.
+if [ "$event" = "Stop" ]; then
+  if [ "$pending" -gt 0 ]; then
+    tmux set -w ${p:+-t "$p"} @claude_pending 1 2>/dev/null
+    exit 0
+  fi
+  tmux set -uw ${p:+-t "$p"} @claude_pending 2>/dev/null
+fi
+
+# From here it's DONE (Stop, no background work) or APPROVAL (permission_prompt).
 sess=$(tmux display      -p ${p:+-t "$p"} '#S' 2>/dev/null)
 tty=$(tmux display       -p ${p:+-t "$p"} '#{pane_tty}' 2>/dev/null)
 wactive=$(tmux display   -p ${p:+-t "$p"} '#{window_active}' 2>/dev/null)
 sattached=$(tmux display -p ${p:+-t "$p"} '#{session_attached}' 2>/dev/null)
 
-# Your tmux client is already on this window → you'll see it; don't ping at all.
+# Your tmux client is already on this window → you'll see it; don't bell/notify.
 [ "$wactive" = "1" ] && [ -n "$sattached" ] && [ "$sattached" != "0" ] && exit 0
 
 # You're elsewhere: ring the bell (BEL 0x07, non-printing) so tmux flags the window.
@@ -37,14 +72,12 @@ TERM_APP="Alacritty"
 front=$(lsappinfo info -only name "$(lsappinfo front 2>/dev/null)" 2>/dev/null)
 case "$front" in *"$TERM_APP"*) exit 0 ;; esac
 
-# You've left the terminal for another app → pop a notification to pull you back.
-# Message reflects which event fired: Stop = response complete and idle;
-# permission_prompt = blocked mid-task waiting for your approval.
+# You've left the terminal → pop a macOS notification to pull you back. Text and
+# sound reflect the outcome: Stop = finished and idle; permission_prompt = blocked
+# mid-task waiting for your approval.
+command -v osascript >/dev/null 2>&1 || exit 0
 if [ "$event" = "Stop" ]; then
-  msg="finished"
+  osascript -e "display notification \"finished\" with title \"Claude · ${sess}\" sound name \"Submarine\"" >/dev/null 2>&1
 else
-  msg="needs approval"
-fi
-if command -v osascript >/dev/null 2>&1; then
-  osascript -e "display notification \"${msg}\" with title \"Claude · ${sess}\" sound name \"Submarine\"" >/dev/null 2>&1
+  osascript -e "display notification \"needs approval\" with title \"Claude · ${sess}\" sound name \"Submarine\"" >/dev/null 2>&1
 fi

--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -35,7 +35,7 @@ bind -N "Choose session/window tree" c choose-tree
 # rows already carry tmux's native '!' bell flag via #{window_flags}. The
 # #{?pane_format,…}/#{?window_format,…} gate picks the right text per row type;
 # the session branch (last) is where session_alerts adds the [!].
-bind -N "Choose session tree (with [!] alert markers)" s choose-tree -Zs -F '#{?pane_format,#{pane_current_command} "#{pane_title}",#{?window_format,#{window_name}#{window_flags},#{?session_alerts,[!] ,}#{session_windows} windows#{?session_attached, (attached),}}}'
+bind -N "Choose session tree (with [!] alert markers)" s choose-tree -Zs -F '#{?pane_format,#{pane_current_command} "#{pane_title}",#{?window_format,#{window_name}#{window_flags}#{?@claude_pending, ⋯,},#{?session_alerts,[!] ,}#{session_windows} windows#{?session_attached, (attached),}}}'
 
 bind -N "Toggle between last two sessions" Space switch-client -l
 
@@ -124,13 +124,22 @@ set -g status-right "${SESSION_ALERTS_}${STATUS_DATE_}"
 # window status - current tab changes color for prefix (red) and copy mode (magenta)
 # In copy mode, the tab name changes to "COPY MODE"
 # Inactive tabs get blue background when prefix is pressed
-set -g window-status-current-format "#{?pane_in_mode,#[fg=black]#[bg=magenta],#{?client_prefix,#[fg=black]#[bg=red],#[fg=red]}}#[bold] #I: #{?pane_in_mode,COPY MODE,#W}#{?monitor-silence, ⏳,}#{?window_zoomed_flag,#[bold]+,}"
-set -g window-status-format "#{?client_prefix,#[fg=black]#[bg=blue],#[fg=blue]} #I: #W#{?monitor-silence, ⏳,}#{?window_zoomed_flag,#[bold]+,}"
+set -g window-status-current-format "#{?pane_in_mode,#[fg=black]#[bg=magenta],#{?client_prefix,#[fg=black]#[bg=red],#[fg=red]}}#[bold] #I: #{?pane_in_mode,COPY MODE,#W}#{?monitor-silence, ⏳,}#{?@claude_pending, ⋯,}#{?window_zoomed_flag,#[bold]+,}"
+set -g window-status-format "#{?client_prefix,#[fg=black]#[bg=blue],#[fg=blue]} #I: #W#{?monitor-silence, ⏳,}#{?@claude_pending, ⋯,}#{?window_zoomed_flag,#[bold]+,}"
 
 set -g window-status-bell-style fg=colour255,bg=colour1,bold
 
 # Flag windows on bell (Claude's hook rings one) — feeds SESSION_ALERTS_ above.
 setw -g monitor-bell on
+
+# Claude's "background work still running" marker (⋯ on the window tab, set by
+# claude_notify.sh on a Stop while background_tasks are pending). Unlike the bell
+# it's a custom option, so clear it when you switch to the window — same
+# self-clear-on-visit feel as the bell. session-window-changed fires on every
+# active-window change (select-window, choose-tree, and M-j/M-k next/previous).
+# Remove this line if you'd rather the ⋯ persist after a glance (it then clears on
+# the window's next completed Claude turn instead).
+set-hook -g session-window-changed 'set -uw @claude_pending'
 
 # The messages
 set -g message-command-style fg=blue,bg=default


### PR DESCRIPTION
Sometimes Claude will "finish" but it's actually waiting on background tasks, in this case we're distinguishing and not sending the full notifications we currently do